### PR TITLE
Updated game versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.shadow)
 }
 
-val baseVersion = "0.0.1"
+val baseVersion = "0.0.2"
 val commitHash = System.getenv("COMMIT_HASH")
 val snapshotversion = "${baseVersion}-dev.$commitHash"
 

--- a/notify-bungeecord/build.gradle.kts
+++ b/notify-bungeecord/build.gradle.kts
@@ -29,7 +29,11 @@ modrinth {
         "1.21.1",
         "1.21.2",
         "1.21.3",
-        "1.21.4"
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8"
     )
     loaders.add("bungeecord")
     changelog.set("https://docs.simplecloud.app/changelog")

--- a/notify-velocity/build.gradle.kts
+++ b/notify-velocity/build.gradle.kts
@@ -31,7 +31,11 @@ modrinth {
         "1.21.1",
         "1.21.2",
         "1.21.3",
-        "1.21.4"
+        "1.21.4",
+        "1.21.5",
+        "1.21.6",
+        "1.21.7",
+        "1.21.8"
     )
     loaders.add("velocity")
     changelog.set("https://docs.simplecloud.app/changelog")


### PR DESCRIPTION
This pull request updates the supported Minecraft versions for both the BungeeCord and Velocity modules. Specifically, it adds support for newer versions while maintaining compatibility with existing ones.

### Updates to supported Minecraft versions:

* [`notify-bungeecord/build.gradle.kts`](diffhunk://#diff-5166d0a60a6d5f9b257ffe3e8ea48c08bc42d8bf3285ab3f563718ae74878cf7L32-R36): Added support for Minecraft versions `1.21.5`, `1.21.6`, `1.21.7`, and `1.21.8` to the `modrinth` configuration.
* [`notify-velocity/build.gradle.kts`](diffhunk://#diff-333389f2b9c6ccc6bb2595b754c0f859356046702bffb0ad2e6d8611be2d3eeeL34-R38): Added support for Minecraft versions `1.21.5`, `1.21.6`, `1.21.7`, and `1.21.8` to the `modrinth` configuration.